### PR TITLE
Code standards for functional programming

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,13 +16,23 @@
     <file>tests</file>
 
     <rule ref="Doctrine">
-        <!-- Ignore type hinting check, it should be done by psalm -->
-        <exclude name="Generic.Files.LineLength.TooLong"/>
-        <exclude name="Squiz.Functions.GlobalFunction.Found"/>
-        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+        <!-- Remove object-oriented programming rules that are incompatible with functional programming paradigm -->
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+        <exclude name="Squiz.Functions.GlobalFunction"/>
+
+        <!-- Keep it closer to Kotlin standards -->
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+        <exclude name="PSR12.Files.OpenTag.NotAlone"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
+        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar"/>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="declareOnFirstLine" value="true" />
+            <property name="linesCountAfterDeclare" value="1" />
+        </properties>
     </rule>
 </ruleset>

--- a/src/Attribute/SinceNiltok.php
+++ b/src/Attribute/SinceNiltok.php
@@ -4,7 +4,8 @@ namespace Codelicia\Niltok\Attribute;
 
 use Attribute;
 
-#[Attribute] final class SinceNiltok
+#[Attribute]
+final class SinceNiltok
 {
     public function __construct(public string $version)
     {

--- a/src/Iterable/windowed.php
+++ b/src/Iterable/windowed.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Iterable;
 

--- a/src/Ranges/IntRange.php
+++ b/src/Ranges/IntRange.php
@@ -1,11 +1,10 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Ranges;
 
 use Codelicia\Niltok\Attribute\SinceNiltok;
 use Countable;
+use InvalidArgumentException;
 use Iterator;
 use Stringable;
 
@@ -22,7 +21,7 @@ final class IntRange implements Iterator, Countable, Stringable
         private readonly int $endInclusive,
     ) {
         if ($this->start > $this->endInclusive) {
-            throw new \InvalidArgumentException("Start cannot be greater than end");
+            throw new InvalidArgumentException('Start cannot be greater than end');
         }
 
         $this->pointer = $this->start;

--- a/src/Standard/Exception/IllegalArgumentException.php
+++ b/src/Standard/Exception/IllegalArgumentException.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard\Exception;
 

--- a/src/Standard/Exception/IllegalStateException.php
+++ b/src/Standard/Exception/IllegalStateException.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard\Exception;
 

--- a/src/Standard/Exception/NotImplementedError.php
+++ b/src/Standard/Exception/NotImplementedError.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard\Exception;
 

--- a/src/Standard/Pair.php
+++ b/src/Standard/Pair.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard;
 

--- a/src/Standard/Result.php
+++ b/src/Standard/Result.php
@@ -1,11 +1,9 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard;
 
-use JsonSerializable;
 use Codelicia\Niltok\Attribute\SinceNiltok;
+use JsonSerializable;
 
 /**
  * A discriminated union that encapsulates a successful outcome with a value of type [T]
@@ -36,6 +34,6 @@ final class Result implements JsonSerializable
 
     public function jsonSerialize(): mixed
     {
-        TODO("In the functional kotlin book, we can actually have an example of Result usage.");
+        TODO('In the functional kotlin book, we can actually have an example of Result usage.');
     }
 }

--- a/src/Standard/TODO.php
+++ b/src/Standard/TODO.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard;
 
@@ -10,8 +8,6 @@ use Codelicia\Niltok\Attribute\SinceNiltok;
  * An exception is thrown to indicate that a method body remains to be implemented.
  *
  * @param string|null $reason a string explaining why the implementation is missing.
- *
- * @return void
  */
 #[SinceNiltok(version: '0.1.0')]
 function TODO(string|null $reason = null): void

--- a/src/Standard/check.php
+++ b/src/Standard/check.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard;
 

--- a/src/Standard/entails.php
+++ b/src/Standard/entails.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard;
 

--- a/src/Standard/error.php
+++ b/src/Standard/error.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard;
 

--- a/src/Standard/println.php
+++ b/src/Standard/println.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard;
 

--- a/src/Standard/repeat.php
+++ b/src/Standard/repeat.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard;
 

--- a/src/Standard/throws.php
+++ b/src/Standard/throws.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\Standard;
 

--- a/src/String/is_blank.php
+++ b/src/String/is_blank.php
@@ -1,10 +1,9 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\String;
 
 use Codelicia\Niltok\Attribute\SinceNiltok;
+
 use function trim;
 
 /**

--- a/src/String/trim_start.php
+++ b/src/String/trim_start.php
@@ -1,10 +1,9 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Codelicia\Niltok\String;
 
 use Codelicia\Niltok\Attribute\SinceNiltok;
+
 use function ltrim;
 
 /**


### PR DESCRIPTION
Remove just the object-oriented programming rules that are incompatible with the functional programming paradigm